### PR TITLE
Update find.sql

### DIFF
--- a/app/config/sql/trips/find.sql
+++ b/app/config/sql/trips/find.sql
@@ -1,1 +1,1 @@
-SELECT * FROM trips WHERE $1^=$2;
+SELECT * FROM trips WHERE $1~=$2;


### PR DESCRIPTION
proper column name escaping, see: [SQL Names](https://github.com/vitaly-t/pg-promise#sql-names).
